### PR TITLE
Add Next.js site scaffold, pages, and docs for Intentcue website

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,34 @@ In this exercise, you will:
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+
+## Local preview for Intentcue website
+
+### Full Next.js app (preferred)
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run development server:
+   ```bash
+   npm run dev
+   ```
+3. Open `http://localhost:3000`.
+
+Available routes:
+- `/` Home landing page
+- `/engine` Universal Prompt Engine overview
+- `/sdk` SDK quickstart page
+- `/founder` Founder perspective page
+
+### No-install fallback preview (for restricted environments)
+
+If npm registry access is blocked, run a static preview:
+
+```bash
+python3 -m http.server 4173
+```
+
+Then open:
+- `http://localhost:4173/preview/`

--- a/app/engine/page.tsx
+++ b/app/engine/page.tsx
@@ -1,0 +1,15 @@
+const blocks = ["Intent Router", "Context Composer", "Policy Guardrails", "Model Adapter", "Eval Gate", "Telemetry & Drift Alerts"];
+
+export default function EnginePage() {
+  return (
+    <div className="container-x py-16">
+      <h1 className="text-3xl font-bold">Universal Prompt Engine</h1>
+      <p className="mt-3 max-w-3xl text-slate-300">See every transformation between user intent and output. PAL compiles intent contracts into provider-native calls while preserving one trace contract.</p>
+      <div className="mt-8 grid gap-3 md:grid-cols-3">
+        {blocks.map((b) => (
+          <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4" key={b}>{b}</div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/founder/page.tsx
+++ b/app/founder/page.tsx
@@ -1,0 +1,13 @@
+export default function FounderPage() {
+  return (
+    <div className="container-x py-16">
+      <h1 className="text-3xl font-bold">Founder Perspective</h1>
+      <p className="mt-4 max-w-3xl text-slate-300">Ravi Kiran Dasari frames prompt management as a software architecture problem. Intentcue exists to make intent behavior explicit, testable, and governable at production scale.</p>
+      <ul className="mt-8 list-disc space-y-2 pl-5 text-slate-300">
+        <li>Prompts are operational state, not static copy.</li>
+        <li>Model swaps should be controlled runtime changes, not app rewrites.</li>
+        <li>Observability and evals belong in the default developer loop.</li>
+      </ul>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 antialiased;
+}
+
+.container-x {
+  @apply mx-auto max-w-6xl px-6;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Intentcue | Intent Orchestration",
+  description: "Intent orchestration for production LLM apps."
+};
+
+const nav = [
+  { href: "/", label: "Home" },
+  { href: "/engine", label: "Engine" },
+  { href: "/sdk", label: "SDK" },
+  { href: "/founder", label: "Founder" }
+];
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="border-b border-slate-800/70 bg-slate-950/90 backdrop-blur">
+          <nav className="container-x flex items-center justify-between py-4">
+            <Link className="font-semibold tracking-wide text-cyan-300" href="/">
+              Intentcue
+            </Link>
+            <ul className="flex gap-5 text-sm text-slate-300">
+              {nav.map((item) => (
+                <li key={item.href}>
+                  <Link className="hover:text-cyan-300" href={item.href}>
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </header>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+const painPoints = [
+  "Prompt drift after model updates",
+  "Fragmented provider payloads and debug workflows",
+  "Unpredictable rollout behavior in production"
+];
+
+export default function HomePage() {
+  return (
+    <div className="container-x py-16">
+      <section className="grid gap-8 md:grid-cols-2 md:items-center">
+        <div>
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-cyan-300">Intent Orchestration, 2026</p>
+          <h1 className="text-4xl font-bold leading-tight md:text-5xl">Ship AI features that stay stable after model changes.</h1>
+          <p className="mt-4 max-w-xl text-slate-300">Intentcue turns fragile prompt strings into versioned, testable intent flows with observability, eval gates, and PAL routing.</p>
+          <div className="mt-8 flex gap-3">
+            <Link className="rounded-lg bg-cyan-400 px-4 py-2 font-medium text-slate-950" href="/sdk">Start in SDK</Link>
+            <Link className="rounded-lg border border-slate-700 px-4 py-2 text-slate-200" href="/engine">Explore Engine</Link>
+          </div>
+        </div>
+        <pre className="overflow-auto rounded-xl border border-slate-800 bg-slate-900 p-5 text-xs text-cyan-200">
+{`const result = await cue.intent.dispatch(["openai","anthropic","groq"], {
+  intent: "support.refund.v2",
+  input: { message: "I was charged twice" },
+  eval: { profile: "strict" }
+});`}
+        </pre>
+      </section>
+
+      <section className="mt-16">
+        <h2 className="text-2xl font-semibold">Why developers switch</h2>
+        <ul className="mt-5 grid gap-3 md:grid-cols-3">
+          {painPoints.map((item) => (
+            <li className="rounded-lg border border-slate-800 bg-slate-900/60 p-4 text-slate-300" key={item}>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/sdk/page.tsx
+++ b/app/sdk/page.tsx
@@ -1,0 +1,17 @@
+export default function SdkPage() {
+  return (
+    <div className="container-x py-16">
+      <h1 className="text-3xl font-bold">SDK Quickstart</h1>
+      <p className="mt-3 text-slate-300">Documentation-first onboarding: install, dispatch, inspect traces, pin intent revisions.</p>
+      <pre className="mt-8 overflow-auto rounded-xl border border-slate-800 bg-slate-900 p-5 text-xs text-cyan-200">
+{`import { Intentcue } from "@intentcue/sdk";
+const cue = new Intentcue({ apiKey: process.env.INTENTCUE_API_KEY! });
+const run = await cue.intent.dispatch(["openai", "anthropic", "groq"], {
+  prompt: "Summarize CAP theorem in 3 bullets.",
+  intent: "docs.summary.v1",
+  temperature: 0.2
+});`}
+      </pre>
+    </div>
+  );
+}

--- a/intentcue-dynamic-value-routing-policy.md
+++ b/intentcue-dynamic-value-routing-policy.md
@@ -1,0 +1,29 @@
+# Intentcue Dynamic Value Routing Policy (Efficiency First)
+
+Intentcue PAL clusters can eliminate monthly manual budget triage by embedding economics directly in routing. Instead of auditing spend after incidents, the cluster continuously optimizes on an **efficiency frontier** where quality and cost are jointly constrained. In practice, this architecture behaves as a built-in financial governor: high-confidence intents are served at low unit cost, while uncertain or deep intents are escalated to premium models to protect outcome quality.
+
+```yaml
+intentcue_policy:
+  id: pal.dynamic-value-routing.v1
+  objective:
+    primary_metric: cpia
+    formula: ic_token_cost / max(ic_intent_score, 0.01)
+    optimize: minimize
+  thresholds:
+    confidence_min: 0.92
+    complexity_depth_max: 7
+  providers:
+    economy: groq
+    premium: [openai, anthropic]
+  routing:
+    - when: "ic_intent_score > confidence_min && intent.depth <= complexity_depth_max"
+      strategy: lowest_cost
+      candidates: [groq]
+    - when: "ic_intent_score <= confidence_min || intent.depth > complexity_depth_max"
+      strategy: best_cpia
+      candidates: [openai, anthropic]
+  enforcement:
+    reevaluate_after_each_response: true
+    fallback_on_provider_error: [openai, anthropic, groq]
+    emit_metrics: [ic_token_cost, ic_intent_score, cpia]
+```

--- a/intentcue-production-hardening-guide.md
+++ b/intentcue-production-hardening-guide.md
@@ -1,0 +1,90 @@
+# Intentcue Production Hardening Guide (PAL Clusters)
+
+> **Relief framing:** You no longer have to worry about hand-coded multi-provider failover trees; Intentcue PAL clusters handle the heavy lifting of retries, circuit breaking, and safe routing.
+
+## Why this reduces cognitive load for SRE teams
+
+Intentcue reduces operational overhead by moving provider-specific failure logic into a single PAL control plane:
+
+- **One policy surface:** retry, breaker, timeout, and fallback are defined once per intent route.
+- **One runtime contract:** all providers emit the same trace envelope and metric keys.
+- **One on-call workflow:** SREs debug cluster events instead of three API dialects.
+- **One rollback lever:** intent revision pinning avoids emergency app redeploys.
+
+Result: fewer moving parts per incident, shorter MTTR, and lower alert fatigue.
+
+---
+
+## 1) Fault-Tolerant Dispatch Strategy
+
+You no longer have to manually catch Groq 5xx errors and stitch fallback logic in app code. Intentcue PAL cluster policies perform automatic retry + breaker + weighted reroute.
+
+```ts
+import { Cluster } from "@intentcue/sdk";
+
+const pal = new Cluster({ id: "prod-pal", providers: ["groq", "anthropic", "openai"] });
+pal.route("chat.support.v3").resilience({
+  retry: { when: "provider=groq && status>=500", attempts: 2, backoffMs: [100, 250] },
+  circuit: { provider: "groq", openAfter: 4, halfOpenAfterMs: 30000 },
+  failover: { onCircuitOpen: ["anthropic", "openai"], strategy: "least_latency" },
+  timeoutMs: 4000
+});
+const result = await pal.dispatch("chat.support.v3", { input: userMessage, eval: "strict" });
+```
+
+### Runtime behavior
+
+1. Groq returns 5xx -> PAL retries twice with bounded backoff.
+2. Repeated failures trip Groq circuit.
+3. Load shifts to Anthropic/OpenAI by least-latency policy.
+4. Circuit probes reopen Groq only after half-open succeeds.
+
+---
+
+## 2) Observability Schema (Unified Markdown Spec)
+
+Intentcue handles the heavy lifting of cross-provider telemetry normalization so you can query one schema for all PAL events.
+
+### Log record contract
+
+| Field | Type | Description |
+|---|---|---|
+| `ic_trace_id` | string | Global run identifier across retries/failovers. |
+| `ic_intent_id` | string | Versioned intent key (e.g., `chat.support.v3`). |
+| `ic_provider` | enum | `openai` \| `anthropic` \| `groq`. |
+| `ic_model` | string | Provider model ID actually invoked. |
+| `ic_latency` | number(ms) | End-to-end provider latency for this attempt. |
+| `ic_token_cost` | number(usd) | Cost computed from normalized token accounting. |
+| `ic_intent_score` | number(0..1) | **Proprietary Intentcue intent-accuracy output** from eval runtime. |
+| `ic_route_action` | enum | `primary` \| `retry` \| `failover` \| `circuit_open`. |
+| `ic_status_code` | number | Provider HTTP status for this attempt. |
+| `ic_cluster` | string | PAL cluster ID handling dispatch. |
+| `ic_timestamp` | string | ISO-8601 event timestamp. |
+
+### Example event (single attempt)
+
+```json
+{
+  "ic_trace_id": "trc_8f2a",
+  "ic_intent_id": "chat.support.v3",
+  "ic_provider": "anthropic",
+  "ic_latency": 812,
+  "ic_token_cost": 0.0039,
+  "ic_intent_score": 0.94,
+  "ic_route_action": "failover"
+}
+```
+
+### SRE starter alerts
+
+- `p95(ic_latency) > 2500ms for 5m by ic_provider`
+- `sum(ic_route_action="circuit_open") > 3 in 10m`
+- `avg(ic_intent_score) < 0.85 for intent_id over 15m`
+
+---
+
+## Self-evaluation checkpoint
+
+- `ic_intent_score` is explicitly defined as a **proprietary Intentcue output**.
+- All code blocks remain under 15 lines.
+- Failover logic uses native PAL cluster methods (`resilience`, `dispatch`), not generic try/catch flows.

--- a/intentcue-sdk-quickstart.md
+++ b/intentcue-sdk-quickstart.md
@@ -1,0 +1,90 @@
+# Intentcue SDK Quickstart (Day Zero)
+
+> **Goal:** Get deterministic multi-LLM dispatch running in minutes, not days.
+
+## Why Intentcue (Relief Framing)
+
+**Problem:** Provider APIs diverge on payload shape, tool-call semantics, retries, and versioning behavior.
+
+**Intentcue fix:** A single **Prompt Abstraction Layer (PAL)** and **universal versioning** model that remove provider-specific integration stress (“API Hell”).
+
+---
+
+## 1) Prompt Abstraction Layer (PAL)
+
+**PAL** is a semantic bridge that decouples **intent definition** from **provider schema**.
+
+- **Input contract:** normalized `intent`, `context`, `constraints`, `evalProfile`.
+- **Compilation step:** PAL compiles the normalized contract into provider-native request envelopes.
+- **Execution layer:** one dispatch call fans out to multiple providers with consistent trace metadata.
+- **Output contract:** normalized `output`, `usage`, `latencyMs`, `safety`, and `traceId`.
+
+### PAL guarantees
+
+1. **Schema isolation:** switching providers does not require prompt rewrite.
+2. **Policy continuity:** guardrails apply before provider adapters.
+3. **Observability parity:** traces remain structurally identical across providers.
+
+---
+
+## 2) Hello World Dispatch (TypeScript)
+
+```ts
+import { Intentcue } from "@intentcue/sdk";
+
+const cue = new Intentcue({ apiKey: process.env.INTENTCUE_API_KEY! });
+const run = await cue.intent.dispatch(["openai", "anthropic", "groq"], {
+  prompt: "Summarize CAP theorem in 3 bullets.",
+  intent: "docs.summary.v1",
+  temperature: 0.2
+});
+console.log(run.results.map(r => [r.provider, r.output]));
+```
+
+**Notes**
+
+- **Line constraint:** snippet body is under 10 lines excluding imports.
+- **Dispatch model:** one call, three providers, normalized response set.
+
+---
+
+## 3) Universal Versioning (Deterministic Model Swaps)
+
+Universal versioning stores **prompt state** independently from provider model version strings.
+
+### Versioned state tuple
+
+`(intent_id, prompt_revision, context_schema_rev, policy_rev, eval_profile_rev)`
+
+### Resolution sequence
+
+1. Client sends `intent_id` (+ optional revision pin).
+2. Runtime resolves immutable prompt state tuple.
+3. PAL compiles tuple into provider-specific payloads.
+4. Adapter injects target model (e.g., `gpt-*`, `claude-*`, `llama-*`).
+5. Trace stores both **state hash** and **provider model id**.
+
+### Determinism behavior
+
+- **Model swap:** provider model can change while prompt state hash remains fixed.
+- **Replayability:** same state hash can be replayed across providers for drift analysis.
+- **Rollback safety:** revert by pinning prior `prompt_revision`; no code redeploy needed.
+
+---
+
+## 4) Day-Zero Integration Checklist
+
+- [ ] Create API key and set `INTENTCUE_API_KEY`.
+- [ ] Register `intent_id` (e.g., `docs.summary.v1`).
+- [ ] Dispatch to `openai`, `anthropic`, `groq` in one call.
+- [ ] Inspect normalized traces and compare provider deltas.
+- [ ] Pin revision in production after eval pass.
+
+---
+
+## 5) Cognitive-Load-Optimized Mental Model
+
+- **Write once:** define intent semantics once.
+- **Dispatch many:** fan out to multiple providers through PAL.
+- **Version once:** persist prompt state independently of model IDs.
+- **Operate calmly:** debug using one trace shape, not three API dialects.

--- a/intentcue-website-roadmap.md
+++ b/intentcue-website-roadmap.md
@@ -1,0 +1,362 @@
+# Intentcue 2026 Digital Presence Roadmap
+
+## 0) Positioning North Star
+
+**Intentcue** is the **Intent Orchestration Layer** between foundation models and production software.
+
+- **Category claim:** “From prompt engineering to intent orchestration.”
+- **Audience:** early-adopter developers, DX leads, AI product engineers, founder-led startup teams.
+- **Core pain:** prompt drift, untraceable behavior changes, and brittle LLM features that burn engineering time.
+- **Core promise:** deterministic orchestration patterns, eval-first shipping, and SDK-native integration paths.
+
+---
+
+## 1) Brand Identity (Tech-Forward + Innovative)
+
+### Brand archetype: **Sage for Builders**
+
+Intentcue should feel like a calm, trusted systems architect in a noisy AI ecosystem.
+
+### Identity pillars
+
+1. **Clarity over hype**
+   - Explain what happens between user intent, policy, context, model, and output.
+2. **Control over chaos**
+   - Versioned intent flows, rollout safety, observability, and testability.
+3. **Velocity with guardrails**
+   - Faster iteration through tooling that catches drift before prod incidents.
+4. **Human-centered DX**
+   - Acknowledge cognitive load and developer burnout from prompt firefighting.
+
+### Empathy framing (burnout-aware messaging)
+
+Use copy patterns that reflect developer lived experience:
+
+- “You’re not bad at prompts. Your system lacks orchestration boundaries.”
+- “Stop babysitting fragile prompts at 2 AM.”
+- “Ship AI features that stay stable after model updates.”
+
+### Voice & tone system
+
+- **Primary tone:** technical, direct, respectful of reader intelligence.
+- **Secondary tone:** wise and composed (Sage persona), never mystical.
+- **Avoid:** generic SaaS language (“unlock value,” “seamless synergy”).
+
+### Tagline candidates
+
+- “Intentcue: Orchestrate intent. Ship reliable AI.”
+- “From prompt strings to production intent systems.”
+- “The control plane for LLM intent in real software.”
+
+---
+
+## 2) Sitemap (Conversion-Oriented)
+
+1. **/** (Landing)
+2. **/engine** (Universal Prompt Engine deep-dive)
+3. **/sdk** (Docs-first SDK portal)
+4. **/playground** (Live playground + examples)
+5. **/founder** (Ravi Kiran Dasari’s perspective)
+6. **/pricing** (Simple early-adopter tiers)
+7. **/changelog** (Trust + velocity signal)
+8. **/docs** (Versioned docs hub)
+9. **/blog** (Technical essays, migration guides, architecture notes)
+10. **/contact** (Waitlist / enterprise channel)
+
+---
+
+## 3) Landing Page Architecture (High-Conversion)
+
+## Section A: Hero
+
+**Goal:** establish category leadership in <8 seconds.
+
+- **Headline:** “Intent Orchestration for Production LLM Apps.”
+- **Subhead:** “Intentcue transforms prompt logic into versioned, testable intent flows your team can deploy safely.”
+- **Primary CTA:** “Start in Playground”
+- **Secondary CTA:** “Read SDK Docs”
+- **Trust strip:** “Model-agnostic • Eval-ready • Runtime-safe • API-first”
+
+**Conversion mechanics**
+
+- Place code preview and runtime graph above the fold.
+- CTA order follows PLG behavior: try first, docs second.
+- Include “No credit card” for early dev adoption.
+
+## Section B: Problem-to-Outcome Narrative
+
+**Developer pain cards**
+
+- Prompt drift after model updates.
+- Copy-pasted prompt variants across services.
+- No clear root-cause trace when behavior regresses.
+
+**Intentcue outcomes**
+
+- Intent contracts and reusable orchestration blocks.
+- Controlled rollouts and diff-aware versioning.
+- Built-in observability and evaluation hooks.
+
+## Section C: Universal Prompt Engine (UI + system mental model)
+
+Show the orchestration graph:
+
+- Intent Router
+- Context Composer
+- Policy Guardrails
+- Model Adapter
+- Eval Gate
+- Telemetry & Drift Alerts
+
+**Microcopy:** “See every transformation between intent and output.”
+
+## Section D: SDK-First Build Path
+
+- 90-second quickstart code block.
+- Tabs: TypeScript / Python / REST.
+- “Copy and run” snippets with deterministic sample outputs.
+- Link to versioned API references.
+
+## Section E: Founder POV
+
+- Short narrative from Ravi Kiran Dasari on why prompt management fails at scale.
+- Emphasis on systems thinking, not one-off hacks.
+
+## Section F: Social Proof / Validation
+
+- Early design partner logos.
+- “Before vs after” engineering metrics (time-to-fix drift, rollout confidence).
+- Changelog heartbeat (“Shipped this week”).
+
+## Section G: Final CTA
+
+- “Build your first orchestrated intent flow in 5 minutes.”
+- Actions: Playground / Docs / Book architecture call.
+
+---
+
+## 4) Detailed Content Guide by Required Sections
+
+## 4.1 Hero (copy blueprint)
+
+**Headline options**
+
+1. “Orchestrate Intent, Not Prompt Strings.”
+2. “The Production Layer Between LLMs and Software.”
+3. “Ship AI Features That Don’t Drift in the Dark.”
+
+**Body copy template**
+
+“Intentcue gives developers a universal intent runtime: route, compose, constrain, evaluate, and observe LLM interactions with versioned control.”
+
+**CTA architecture**
+
+- Primary: Playground trial.
+- Secondary: SDK docs.
+- Tertiary (low emphasis): Founder manifesto.
+
+## 4.2 Universal Prompt Engine (documentation-style product page)
+
+### Recommended page structure
+
+1. **What it is** (single paragraph)
+2. **How it works** (pipeline diagram + short explanation)
+3. **Core abstractions**
+   - Intent
+   - Context Pack
+   - Policy Set
+   - Route Strategy
+   - Eval Spec
+4. **Runtime lifecycle**
+   - Author → Test → Version → Deploy → Observe → Iterate
+5. **Production controls**
+   - Canary rollouts, fallback chains, policy assertions
+6. **API references** (deep links)
+7. **Cookbook examples**
+
+### Technical copy themes
+
+- “Model upgrades should be a config change, not a rewrite.”
+- “Every intent execution has trace IDs, snapshots, and eval verdicts.”
+
+## 4.3 SDK (documentation-first)
+
+### Docs IA (information architecture)
+
+1. **Quickstart**
+2. **Install**
+3. **Core concepts**
+4. **Hello Intentcue**
+5. **Guides**
+   - Routing
+   - Guardrails
+   - Evaluation
+   - Streaming
+6. **API Reference**
+7. **Examples repo links**
+8. **Migration notes**
+9. **Troubleshooting**
+10. **CLI reference**
+
+### Example first-screen SDK content
+
+```ts
+import { Intentcue } from "@intentcue/sdk";
+
+const cue = new Intentcue({ apiKey: process.env.INTENTCUE_API_KEY });
+
+const result = await cue.intent.run({
+  id: "support.refund.v2",
+  input: { message: "I was charged twice" },
+  context: { plan: "pro", locale: "en-US" },
+  eval: { profile: "strict" }
+});
+
+console.log(result.output);
+console.log(result.trace.id, result.eval.verdict);
+```
+
+### DX details that drive conversion
+
+- One command install + one endpoint test.
+- Language parity between TypeScript and Python.
+- Version switcher pinned in left nav.
+- Inline “why this matters” callouts to reduce cognitive load.
+
+## 4.4 Founder Section (Ravi Kiran Dasari)
+
+### Positioning angle
+
+Ravi’s unique perspective should frame prompt management as a **software architecture concern** rather than copywriting.
+
+### Suggested founder narrative
+
+- “Prompting became a hidden operations tax.”
+- “Intentcue was built to make behavior explicit, testable, and governable.”
+- “The mission: remove uncertainty from LLM product development.”
+
+### Founder content modules
+
+1. **Manifesto excerpt** (short and technical)
+2. **Architecture principles** (3-5 bullets)
+3. **Video clip / annotated whiteboard**
+4. **Links to technical essays**
+
+---
+
+## 5) Tree of Thoughts: Lead With Engine UI or SDK Code?
+
+### Option A — Lead with Engine UI
+
+- **Pros:** visual clarity; easier category explanation.
+- **Cons:** can feel abstract to builders seeking immediate code proof.
+
+### Option B — Lead with SDK Code
+
+- **Pros:** instant credibility with developer audience; faster activation.
+- **Cons:** category story may be unclear without orchestration mental model.
+
+### Option C — Hybrid (Recommended)
+
+- Hero starts with category headline + tiny code snippet + graph preview.
+- First CTA = Playground (hands-on), second CTA = Docs (reference).
+- Follow with Engine visualization once interest is earned.
+
+**Decision (based on 2026 PLG behavior):** Use **Hybrid**, but anchor conversion around code-first activation paths.
+
+---
+
+## 6) Friction Audit + Self-Evaluation
+
+### Likely friction points for new users
+
+1. **Conceptual overhead:** “Intent orchestration” sounds abstract.
+2. **Trust gap:** concern about runtime latency and lock-in.
+3. **Setup anxiety:** fear of long integration cycles.
+4. **Observability uncertainty:** unclear debug workflow.
+
+### Mitigation plan
+
+- Add a **Live Playground** with shareable traces and side-by-side model comparisons.
+- Publish latency benchmarks and architecture constraints transparently.
+- Provide 5-minute “Hello Intentcue” starter templates.
+- Include “From raw prompt to orchestrated intent” migration wizard.
+
+### Live Playground requirements
+
+- Preloaded flows (support, summarization, extraction).
+- Intent graph visualization + raw logs toggle.
+- Drift simulation mode (change model version and inspect impact).
+- “Export to SDK snippet” button.
+
+---
+
+## 7) Recommended Tech Stack (Next.js + Tailwind)
+
+### Frontend
+
+- **Framework:** Next.js (App Router)
+- **UI:** Tailwind CSS + shadcn/ui style primitives
+- **Content:** MDX for docs and changelog
+- **Search:** local indexed docs search (or Algolia DocSearch)
+
+### Backend / platform
+
+- Edge-ready API routes for playground proxy
+- Postgres + Redis for sessions/traces metadata
+- Object store for execution snapshots
+
+### Developer content ops
+
+- Docs sourced from versioned markdown in repo
+- Auto-generate API references from OpenAPI/typed SDK docs
+- CI link checker + docs lint + snippet tests
+
+### Instrumentation
+
+- Web analytics for funnel steps (hero -> playground -> key generation -> first API call)
+- Event taxonomy for activation milestones
+
+---
+
+## 8) 90-Day Launch Roadmap
+
+### Phase 1 (Weeks 1-3): Foundations
+
+- Finalize messaging framework and visual identity.
+- Build landing page skeleton and docs IA.
+- Ship SDK quickstart and copy-paste snippets.
+
+### Phase 2 (Weeks 4-7): Activation Engine
+
+- Launch Live Playground MVP.
+- Publish 3 canonical examples and one migration guide.
+- Add changelog and weekly shipping cadence.
+
+### Phase 3 (Weeks 8-10): Trust + Scale
+
+- Add drift case study and early partner quotes.
+- Introduce benchmark/latency disclosure page.
+- Expand docs with troubleshooting and eval guides.
+
+### Phase 4 (Weeks 11-13): Conversion Optimization
+
+- A/B test hero headline + CTA ordering.
+- Optimize onboarding from playground to API key generation.
+- Add “book architecture call” path for larger teams.
+
+---
+
+## 9) Success Metrics (North-Star + Leading Indicators)
+
+- **Activation:** % visitors who run first playground flow.
+- **Developer conversion:** % that generate API key after docs visit.
+- **Time-to-first-success:** median minutes from landing to first successful intent execution.
+- **Retention signal:** weekly returning builders using traces/evals.
+- **Narrative resonance:** founder page to docs click-through rate.
+
+---
+
+## 10) Final Synthesis for Ravi Kiran Dasari
+
+To launch Intentcue effectively in 2026, position it as the **production intent control plane** for serious builders. Lead with empathy for teams exhausted by prompt drift, then prove credibility through a code-first path and transparent runtime mechanics. Pair a documentation-first SDK with a live playground that turns abstract orchestration into an immediately testable experience. Frame Ravi’s voice as the architectural compass: from fragile prompt hacks to governed intent systems that can scale with confidence.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "intentcue-site",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.3.1",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "22.15.3",
+    "@types/react": "19.0.8",
+    "@types/react-dom": "19.0.3",
+    "autoprefixer": "10.4.21",
+    "postcss": "8.5.3",
+    "tailwindcss": "3.4.17",
+    "typescript": "5.8.3"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/preview/index.html
+++ b/preview/index.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Intentcue Preview</title>
+    <style>
+      body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #020617; color: #e2e8f0; }
+      .wrap { max-width: 960px; margin: 0 auto; padding: 32px 20px; }
+      .card { border: 1px solid #1e293b; background: #0f172a; border-radius: 12px; padding: 16px; }
+      .grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(220px,1fr)); gap: 12px; }
+      code, pre { color: #67e8f9; }
+      a { color: #67e8f9; text-decoration: none; }
+      a:hover { text-decoration: underline; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Intentcue — Intent Orchestration for Production LLM Apps</h1>
+      <p>Fallback static preview for restricted environments where npm install is blocked.</p>
+      <div class="card">
+<pre>const run = await cue.intent.dispatch(["openai", "anthropic", "groq"], {
+  intent: "support.refund.v2",
+  input: { message: "I was charged twice" },
+  eval: { profile: "strict" }
+});</pre>
+      </div>
+      <h2>Why developers switch</h2>
+      <div class="grid">
+        <div class="card">Prompt drift after model updates</div>
+        <div class="card">Fragmented provider payloads and debug workflows</div>
+        <div class="card">Unpredictable rollout behavior in production</div>
+      </div>
+
+      <h2 style="margin-top: 28px">Routes in full Next.js app</h2>
+      <ul>
+        <li><strong>/</strong> Home</li>
+        <li><strong>/engine</strong> Universal Prompt Engine</li>
+        <li><strong>/sdk</strong> SDK Quickstart</li>
+        <li><strong>/founder</strong> Founder Perspective</li>
+      </ul>
+
+      <p style="margin-top: 20px">When npm access is available, run the full app via <code>npm install && npm run dev</code>.</p>
+    </div>
+  </body>
+</html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{js,ts,jsx,tsx,mdx}"],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation

- Provide a documentation-first landing site and static fallback for Intentcue to explain the product and onboarding flows. 
- Enable local development and quick preview of the marketing/docs content for SDK, Engine, and Founder view. 
- Surface production guidance, routing policy, and SDK quickstarts as versioned markdown to support developer onboarding.

### Description

- Add a Next.js App Router site scaffold including `app/layout.tsx`, `app/page.tsx`, `app/engine/page.tsx`, `app/sdk/page.tsx`, and `app/founder/page.tsx` with Tailwind styling via `app/globals.css` and `tailwind.config.ts`.
- Add build and dev configuration files: `package.json`, `next.config.mjs`, `postcss.config.mjs`, `tsconfig.json`, and `next-env.d.ts`.
- Add a static no-install preview at `preview/index.html` and update `README.md` with local preview instructions and available routes.
- Add documentation and product artifacts: `intentcue-sdk-quickstart.md`, `intentcue-production-hardening-guide.md`, `intentcue-dynamic-value-routing-policy.md`, and an extensive `intentcue-website-roadmap.md`.

### Testing

- No automated tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e432dcc15c8333b4e8d4fd5697e113)